### PR TITLE
Query param enum values (0.23.0-RC1.2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val publishing = Seq(
     Some(ScmInfo(url(s"https://$base"), s"scm:git:https://$base", Some(s"scm:git:git@$base")))
   },
   packageDoc / publishArtifact := false,
-  packageSrc / publishArtifact := false
+  packageSrc / publishArtifact := true
 )
 
 lazy val extras = (ThisBuild / pomExtra) := (

--- a/core/core.sbt
+++ b/core/core.sbt
@@ -2,5 +2,5 @@ name := "rho-core"
 
 description := "Rho - A self documenting DSL built on http4s"
 
-version := "0.23.0-RC1.1"
+version := "0.23.0-RC1.2"
 

--- a/core/core.sbt
+++ b/core/core.sbt
@@ -1,3 +1,6 @@
 name := "rho-core"
 
 description := "Rho - A self documenting DSL built on http4s"
+
+version := "0.23.0-RC1.1"
+

--- a/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
@@ -28,8 +28,9 @@ case class QueryMetaData[F[_], T](
     description: Option[String],
     p: QueryParser[F, T],
     default: Option[T],
-    m: TypeTag[T])
-    extends Metadata
+    m: TypeTag[T],
+    enums: Seq[String] = Nil
+) extends Metadata
 
 /** Metadata about a header rule */
 case class HeaderMetaData[T](key: CIString, isRequired: Boolean) extends Metadata

--- a/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
@@ -18,13 +18,17 @@ object PathTree {
     new ops.PathTree(ops.MatchNode(Uri.Path.Segment.empty))
   }
 
-  def splitPath(path: Uri.Path): List[Uri.Path.Segment] = {
-    val fixEmpty =
-      if (path.isEmpty) List(Uri.Path.Segment.empty)
-      else path.segments.filterNot(_.isEmpty).toList
-    if (path.endsWithSlash) fixEmpty :+ Uri.Path.Segment.empty
-    else fixEmpty
-  }
+  def splitPath(path: Uri.Path): List[Uri.Path.Segment] =
+    if (path.isEmpty) {
+      List(Uri.Path.Segment.empty)
+    } else {
+      val noEmptySegments = path.segments.filterNot(_.isEmpty).toList
+      if (path.endsWithSlash) {
+        noEmptySegments :+ Uri.Path.Segment.empty
+      } else {
+        noEmptySegments
+      }
+    }
 }
 
 private[rho] trait PathTreeOps[F[_]] extends RuleExecutor[F] {

--- a/core/src/main/scala/org/http4s/rho/bits/TypedASTs.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/TypedASTs.scala
@@ -131,7 +131,7 @@ final case class TypedQuery[F[_], T <: HList](rule: RequestRule[F]) extends UriC
     @scala.annotation.tailrec
     def go(rule: List[RequestRule[F]], acc: List[String]): List[String] = rule match {
       case Nil => acc
-      case MetaRule(q, QueryMetaData(n, _, _, _, _)) :: rs => go(q :: rs, n :: acc)
+      case MetaRule(q, QueryMetaData(n, _, _, _, _, _)) :: rs => go(q :: rs, n :: acc)
       case MetaRule(q, _) :: rs => go(q :: rs, acc)
       case AndRule(a, b) :: rs => go(a :: b :: rs, acc)
       case OrRule(a, _) :: rs => go(a :: rs, acc)
@@ -159,7 +159,7 @@ object TypedQuery {
         getKey(t.rule).getOrElse(sys.error("Empty Query doesn't have a key name"))
 
       private def getKey(rule: RequestRule[F]): Option[QueryParameterKey] = rule match {
-        case MetaRule(_, QueryMetaData(n, _, _, _, _)) => Some(QueryParameterKey(n))
+        case MetaRule(_, QueryMetaData(n, _, _, _, _, _)) => Some(QueryParameterKey(n))
         case MetaRule(r, _) => getKey(r)
         case OrRule(a, b) => getKey(a).orElse(getKey(b))
         case IgnoreRule(r) => getKey(r)

--- a/core/src/main/scala/org/http4s/rho/bits/UriConverter.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/UriConverter.scala
@@ -34,7 +34,7 @@ object UriConverter {
     @scala.annotation.tailrec
     def go(rule: List[RequestRule[F]], acc: Query): Try[Query] = rule match {
       case Nil => Success(acc.reverse)
-      case MetaRule(r, QueryMetaData(n, _, _, _, _)) :: rs => go(r :: rs, ParamExp(n) :: acc)
+      case MetaRule(r, QueryMetaData(n, _, _, _, _, _)) :: rs => go(r :: rs, ParamExp(n) :: acc)
       case MetaRule(r, _) :: rs => go(r :: rs, acc)
       case AndRule(a, b) :: rs => go(a :: b :: rs, acc)
       case (EmptyRule() | CaptureRule(_)) :: rs => go(rs, acc)

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -75,7 +75,7 @@ private[swagger] class SwaggerModelsBuilder[F[_]](formats: SwaggerFormats)(impli
         case (EmptyRule() | CaptureRule(_)) :: xs => go(xs)
         case MapRule(r, _) :: xs => go(r :: xs)
         case IgnoreRule(r) :: xs => go(r :: xs)
-        case MetaRule(x, q @ QueryMetaData(_, _, _, _, _)) :: xs =>
+        case MetaRule(x, q @ QueryMetaData(_, _, _, _, _, _)) :: xs =>
           val tpe = q.m.tpe
           TypeBuilder.DataType.fromType(tpe) match {
             case _: TypeBuilder.DataType.ComplexDataType =>
@@ -205,7 +205,7 @@ private[swagger] class SwaggerModelsBuilder[F[_]](formats: SwaggerFormats)(impli
           addOrDescriptions(set)(as, bs, "params") :::
             addOrDescriptions(set)(bs, as, "params")
 
-        case MetaRule(rs, q @ QueryMetaData(_, _, _, _, _)) :: xs =>
+        case MetaRule(rs, q @ QueryMetaData(_, _, _, _, _, _)) :: xs =>
           mkQueryParam(q.asInstanceOf[QueryMetaData[F, _]]) :: go(rs :: xs)
 
         case MetaRule(rs, m: TextMetaData) :: xs =>
@@ -439,7 +439,7 @@ private[swagger] class SwaggerModelsBuilder[F[_]](formats: SwaggerFormats)(impli
           description = rule.description,
           required = required,
           defaultValue = rule.default.map(_.toString),
-          enums = enums.toList
+          enums = if (rule.enums.nonEmpty) rule.enums.toList else enums.toList
         )
     }
   }

--- a/swagger/swagger.sbt
+++ b/swagger/swagger.sbt
@@ -2,5 +2,5 @@ name := "rho-swagger"
 
 description := "Swagger support for Rho"
 
-version := "0.23.0-RC1.1"
+version := "0.23.0-RC1.2"
 

--- a/swagger/swagger.sbt
+++ b/swagger/swagger.sbt
@@ -1,3 +1,6 @@
 name := "rho-swagger"
 
 description := "Swagger support for Rho"
+
+version := "0.23.0-RC1.1"
+


### PR DESCRIPTION
Add support to provide a list of allowed values for enum query parameters

Example: 
```
sealed trait Brand

object Brand {
  case object BmwMotors
  case object AudiMotors
  case object PorsheMotors
}

paramE[Brand]("brand", List("bmw","audi","porshe"))
```